### PR TITLE
feat: post-liquidation storage

### DIFF
--- a/contracts/core/Controller.sol
+++ b/contracts/core/Controller.sol
@@ -452,12 +452,10 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
 
     /**
      * @notice clear a vaults liquidation details
-     * @param _owner account owner of the vault
      * @param _vaultId vaultId to return balances for
      */
-    function clearVaultLiquidationDetails(address _owner, uint256 _vaultId) external {
-        require(_owner == msg.sender);
-        delete vaultLiquidationDetails[_owner][_vaultId];
+    function clearVaultLiquidationDetails(uint256 _vaultId) external {
+        delete vaultLiquidationDetails[msg.sender][_vaultId];
     }
 
     /**
@@ -1036,12 +1034,12 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
             _args.vaultId
         ];
         if (vaultLiqDetails.series == vault.shortOtokens[0]) {
-            vaultLiqDetails.shortAmount += _args.amount;
-            vaultLiqDetails.collateralAmount += collateralToSell;
+            vaultLiqDetails.shortAmount += uint128(_args.amount);
+            vaultLiqDetails.collateralAmount += uint128(collateralToSell);
         } else {
             vaultLiqDetails.series = vault.shortOtokens[0];
-            vaultLiqDetails.shortAmount = _args.amount;
-            vaultLiqDetails.collateralAmount = collateralToSell;
+            vaultLiqDetails.shortAmount = uint128(_args.amount);
+            vaultLiqDetails.collateralAmount = uint128(collateralToSell);
         }
         // decrease amount of collateral in liquidated vault, index of collateral to decrease is hardcoded at 0
         vaults[_args.owner][_args.vaultId].removeCollateral(vault.collateralAssets[0], collateralToSell, 0);

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -51,8 +51,8 @@ library MarginVault {
     // a given liquidation
     struct VaultLiquidationDetails {
         address series;
-        uint256 shortAmount;
-        uint256 collateralAmount;
+        uint128 shortAmount;
+        uint128 collateralAmount;
     }
 
     /**

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -47,6 +47,14 @@ library MarginVault {
         uint256[] collateralAmounts;
     }
 
+    // vaultLiquidationDetails is a struct of 3 variables that store the series address, short amount liquidated and collateral transferred for
+    // a given liquidation
+    struct VaultLiquidationDetails {
+        address series;
+        uint256 shortAmount;
+        uint256 collateralAmount;
+    }
+
     /**
      * @dev increase the short oToken balance in a vault when a new oToken is minted
      * @param _vault vault to add or increase the short position in


### PR DESCRIPTION
# Task: Post liquidation storage

## High Level Description

Store the details of a liquidation in a mapping struct after a liquidation, this can be queried until it is cleared by the vault owner.